### PR TITLE
We should read a pointer, not an int()

### DIFF
--- a/src/main/java/edu/nyu/physics/gershowlab/mmf/IplImageHeader.java
+++ b/src/main/java/edu/nyu/physics/gershowlab/mmf/IplImageHeader.java
@@ -180,7 +180,7 @@ public class IplImageHeader {
 		    for (int i = 0; i < BorderConst.length; ++i) {
 		    	BorderConst[i] = raf.readInt();
 		    }
-		    imageDataOriginPTR = raf.readInt();
+		    imageDataOriginPTR = readPointer(raf);
 		    if (raf.getFilePointer() - pos != nSize) {
 		    	throw new IOException("did not read correct number of bytes from IplImage Header");//should never happen
 		    }


### PR DESCRIPTION
This was breaking reading mmf files with nSize 136 :-)
